### PR TITLE
fix: change the naming of the airtable method from updateRecords to u…

### DIFF
--- a/src/airtable/airtable.service.spec.ts
+++ b/src/airtable/airtable.service.spec.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 export const mockAirtableService = {
   getRecords: jest.fn().mockReturnValue(new Observable()),
   getView: jest.fn().mockReturnValue(new Observable()),
-  updateRecords: jest.fn().mockReturnValue(new Observable()),
+  updateCodeSpecRecords: jest.fn().mockReturnValue(new Observable()),
   createField: jest.fn().mockReturnValue(new Observable()),
 };
 
@@ -51,13 +51,19 @@ describe('AirtableService', () => {
     expect(records).toBeDefined();
   });
 
-  it('should patch (update) the view and return observable', () => {
+  it('should patch (update) the code spec match records and return observable', () => {
     // arrange
-    const recordId = 'record123';
+    const fieldName = 'Code Spec Match';
     // actual
-    const response = service.updateRecords(baseId, tableId, [], token);
+    const response = service.updateCodeSpecRecords(
+      baseId,
+      tableId,
+      [],
+      fieldName,
+      token,
+    );
     // assert
-    expect(mockAirtableService.updateRecords).toHaveBeenCalledWith(
+    expect(mockAirtableService.updateCodeSpecRecords).toHaveBeenCalledWith(
       baseId,
       tableId,
       [],

--- a/src/airtable/airtable.service.ts
+++ b/src/airtable/airtable.service.ts
@@ -44,30 +44,35 @@ export class AirtableService {
   }
 
   /**
-   * Updates one or multiple records in a table.
+   * Updates one or multiple code spec examination records in a table.
    *
    * @param baseId The id of the base.
    * @param tableId The id of the table.
    * @param records An array of objects containing the id, field and value of the record(s) to update.
+   * @param fieldName The name of the field to update.
    * @param token The API key for the Airtable API.
    *
    * @returns An Observable of the HTTP response from the Airtable API.
    */
-  updateRecords(
+  updateCodeSpecRecords(
     baseId: string,
     tableId: string,
     records: Array<any>,
+    fieldName: string,
     token: string,
   ) {
     // Build the URL for the API request.
     const url = `https://api.airtable.com/v0/${baseId}/${tableId}`;
-    const codeSpecMatch = records.map(record => {
-      return {
-        id: record.id,
-        fields: {
-          'Code Spec Match': record.fields['Code Spec Match'],
-        },
-      };
+
+    // Build the records to update.
+    const updatedRecords = records.map(record => {
+      const updatedRecord = { id: record.id, fields: {} };
+      Object.entries(record.fields).forEach(([key, value]) => {
+        if (key === fieldName) {
+          updatedRecord.fields[fieldName] = value;
+        }
+      });
+      return updatedRecord;
     });
 
     // Build the headers for the API request.
@@ -78,7 +83,7 @@ export class AirtableService {
 
     // Build the request body.
     const body = JSON.stringify({
-      records: codeSpecMatch,
+      records: updatedRecords,
       typecast: true,
     });
 

--- a/src/data-layer-checker/data-layer-checker.controller.spec.ts
+++ b/src/data-layer-checker/data-layer-checker.controller.spec.ts
@@ -48,8 +48,14 @@ describe('DataLayerCheckerController', () => {
   describe('should get airtable records; handle data checking operation; update multiple records in batch of 10', () => {
     it('should examinationResults', () => {
       // arrange
+      const fieldName = 'Code Spec Match';
       // act
-      controller.checkCodeSpecsAndUpdateRecords(baseId, tableId, token);
+      controller.checkCodeSpecsAndUpdateRecords(
+        baseId,
+        tableId,
+        fieldName,
+        token,
+      );
       // assert
       expect(service.checkCodeSpecsAndUpdateRecords).toHaveBeenCalled();
       expect(service.checkCodeSpecsAndUpdateRecords).toBeCalledTimes(1);

--- a/src/data-layer-checker/data-layer-checker.controller.ts
+++ b/src/data-layer-checker/data-layer-checker.controller.ts
@@ -12,11 +12,13 @@ export class DataLayerCheckerController {
   checkCodeSpecsAndUpdateRecords(
     @Param('baseId') baseId: string,
     @Param('tableId') tableId: string,
+    @Query('fieldName') fieldName: string,
     @Query('token') token: string,
   ) {
     this.dataLayerCheckerService.checkCodeSpecsAndUpdateRecords(
       baseId,
       tableId,
+      fieldName,
       token,
     );
   }

--- a/src/data-layer-checker/data-layer-checker.service.ts
+++ b/src/data-layer-checker/data-layer-checker.service.ts
@@ -75,12 +75,14 @@ export class DataLayerCheckerService {
    * checkCodeSpecsAndUpdateRecords
    * @param {string} baseId - the base ID for the Airtable API
    * @param {string} tableId - the table ID for the Airtable API
+   * @param {string} fieldName - the field name to update {Code Spec Match
    * @param {string} token - the API token for the Airtable API
    * @returns void
    */
   checkCodeSpecsAndUpdateRecords(
     baseId: string,
     tableId: string,
+    fieldName: string,
     token: string,
   ) {
     const records: Observable<any> = this.airtableService.getRecords(
@@ -110,7 +112,7 @@ export class DataLayerCheckerService {
           // Update the records in batches
           for (const batch of batches) {
             this.airtableService
-              .updateRecords(baseId, tableId, batch, token)
+              .updateCodeSpecRecords(baseId, tableId, batch, fieldName, token)
               .subscribe(res => {
                 console.log('res: ', res.status);
               });


### PR DESCRIPTION
fix: change the naming of the airtable method from updateRecords to updateCodeSpecRecords

since the method only patch the code spec checking result, it will be more descriptive; fix: change the tests and related implementations accordingly