### PR TITLE
func: refactor the entire Puppeteer codebase to run parallel Puppeteer instances

### DIFF
--- a/src/data-layer-checker/data-layer-checker.service.ts
+++ b/src/data-layer-checker/data-layer-checker.service.ts
@@ -4,6 +4,7 @@ import { PuppeteerService } from '../puppeteer/puppeteer.service';
 import { AirtableService } from '../airtable/airtable.service';
 import { GtmOperatorService } from '../gtm-operator/gtm-operator.service';
 import { ExtractOperation } from '../interfaces/getOperation.interface';
+import { chunk } from '../utils/util';
 
 /**
  * DataLayerCheckerService
@@ -187,7 +188,7 @@ export class DataLayerCheckerService implements ExtractOperation {
           }
 
           // Split the results into batches of 10
-          const batches = this.chunk(await results, 10);
+          const batches = chunk(await results, 10);
 
           // Update the records in batches
           for (const batch of batches) {
@@ -202,15 +203,14 @@ export class DataLayerCheckerService implements ExtractOperation {
       .subscribe();
   }
 
-  chunk(array: any[], chunkSize: number) {
-    return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) =>
-      array.slice(i * chunkSize, i * chunkSize + chunkSize),
-    );
-  }
-
   async checkCodeSpecsViaGtm(gtmUrl: string, title: string) {
-    await this.gtmOperatorService.goToPageViaGtm(gtmUrl, '', 'false');
-    const page = await this.gtmOperatorService.locateTestingPage();
+    // await this.gtmOperatorService.goToPageViaGtm(gtmUrl, '', 'false');
+    const { browser, page } = await this.gtmOperatorService.goToPageViaGtm(
+      gtmUrl,
+      '',
+      'false',
+    );
+    // const page = await this.gtmOperatorService.locateTestingPage();
     // TODO: should grab operation data from Airtable
     const operation = this.getOperationJson(title);
     await this.puppeteerService.performOperationViaGtm(page, operation);

--- a/src/gtm-operator/gtm-operator.controller.spec.ts
+++ b/src/gtm-operator/gtm-operator.controller.spec.ts
@@ -41,6 +41,7 @@ describe('GtmOperatorController', () => {
       const gtmUrl = 'https://tagmanager.google.com';
       const expectValue = 'G111';
       const loops = 3;
+      const chunks = 1;
       const settings = '--incognito';
       const headless = 'false';
       // act
@@ -48,6 +49,7 @@ describe('GtmOperatorController', () => {
         gtmUrl,
         expectValue,
         loops,
+        chunks,
         settings,
         headless,
       );

--- a/src/gtm-operator/gtm-operator.controller.ts
+++ b/src/gtm-operator/gtm-operator.controller.ts
@@ -15,6 +15,7 @@ export class GtmOperatorController {
     @Query('gtmUrl') gtmUrl: string,
     @Query('expectValue') expectValue: string,
     @Query('loops') loops = 1,
+    @Query('chunks') chunks = 1,
     @Query('args') args: string = '--incognito',
     @Query('headless') headless = 'false',
   ) {
@@ -22,6 +23,7 @@ export class GtmOperatorController {
       gtmUrl,
       expectValue,
       loops,
+      chunks,
       args,
       headless,
     );

--- a/src/gtm-operator/gtm-operator.service.ts
+++ b/src/gtm-operator/gtm-operator.service.ts
@@ -1,22 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { PuppeteerService } from '../puppeteer/puppeteer.service';
 import { Page } from 'puppeteer';
+import { chunk } from '../utils/util';
 
 /**
- * @class GtmOperatorService
- * Service for interacting with Google Tag Manager and observing the Google Conversion Services
+ * A service for interacting with Google Tag Manager (GTM) via Puppeteer.
  */
 @Injectable()
 export class GtmOperatorService {
   constructor(public puppeteerService: PuppeteerService) {}
-  testingPage: Page;
 
   /**
-   * Go to a page via GTM interface
-   *
-   * @param {string} gtmUrl URL of the Google Tag Manager interface
-   * @param {string} [args] command line arguments to pass to the browser instance
-   * @param {string} [headless] 'true' to run the browser in headless mode, 'false' otherwise
+   * Goes to a GTM URL and returns the browser and page instances.
+   * @param gtmUrl The URL of the GTM interface.
+   * @param args Optional command-line arguments to pass to the browser instance.
+   * @param headless Optional boolean flag indicating whether to run the browser in headless mode.
+   * @returns An object containing the browser and page instances.
    */
   async goToPageViaGtm(gtmUrl: string, args?: string, headless?: string) {
     // 1) Open the GTM interface
@@ -24,13 +23,13 @@ export class GtmOperatorService {
       .split('&')
       .find(element => element.startsWith('url='))
       .split('=')[1];
-    await this.puppeteerService.initPuppeteerService({
+
+    const browser = await this.puppeteerService.initAndReturnBrowser({
       headless: headless.toLowerCase() === 'true' ? true : false || false,
       args: args.split(','),
     });
-    await this.puppeteerService.goToPage(gtmUrl);
-    const broswer = this.puppeteerService.getBrowser();
-    const page = this.puppeteerService.getPage();
+
+    const page = await this.puppeteerService.gotoAndReturnPage(gtmUrl, browser);
 
     // 2) Do not include the debug mode
     await page.$('#include-debug-param').then(el => el?.click());
@@ -39,21 +38,19 @@ export class GtmOperatorService {
     await page.$('#domain-start-button').then(el => el?.click());
 
     // 4) Wait for the page to completely load
-    await broswer.waitForTarget(target => target.url() === websiteUrl);
+    await browser.waitForTarget(target => target.url() === websiteUrl);
+    return { browser, page };
   }
 
   /**
-   * Crawl the current page's responses and extract the ones containing the Google Consent Status parameter
-   *
-   * @returns Array of URLs with the 'gcs' parameter
+   * Crawls the page responses for URLs containing the `gcs` parameter and returns them in an array.
+   * @param page The page to crawl.
+   * @returns An array of URLs containing the `gcs` parameter.
    */
-  async crawlPageResponses() {
+  async crawlPageResponses(page: Page) {
     const responses: string[] = [];
-    // 1) Get the page
-    const page = await this.locateTestingPage();
-    this.testingPage = page; // assign the variable for later use
 
-    // 2) Listen to all responses, push the ones that contain the gcs parameter
+    // 1) Listen to all responses, push the ones that contain the gcs parameter
     page.on('response', async response => {
       try {
         if (response.request().url().includes('gcs=')) {
@@ -65,99 +62,92 @@ export class GtmOperatorService {
     });
 
     await page.waitForResponse(response => response.url().includes('gcs='));
-    // await page.close();
     return responses;
   }
 
   /**
-   * Locate the currently open testing page
-   *
-   * @returns Currently open testing page
+   * Observes the Google Consent States (GCS) via GTM and returns them in an array.
+   * @param gtmUrl The URL of the GTM interface.
+   * @param args Optional command-line arguments to pass to the browser instance.
+   * @param headless Optional boolean flag indicating whether to run the browser in headless mode.
+   * @returns An object containing the browser instance and an array of GCS.
    */
-  async locateTestingPage() {
-    const browser = this.puppeteerService.getBrowser();
+  async observeGcsViaGtm(gtmUrl: string, args?: string, headless?: string) {
+    const { browser, page } = await this.goToPageViaGtm(gtmUrl, args, headless);
     const pages = await browser.pages();
-    return pages[pages.length - 1];
+    const responses = await this.crawlPageResponses(pages[pages.length - 1]);
+    const gcs = this.puppeteerService.getGcs(responses);
+    return { browser, gcs };
   }
 
   /**
-   * @method observeGcsViaGtm
-   * Observe the Google Conversion Services of a page via GTM interface
-   *
-   * @param {string} gtmUrl URL of the Google Tag Manager interface
-   * @param {string} [args] command line arguments to pass to the browser instance
-   * @param {string} [headless] 'true' to run the browser in headless mode, 'false' otherwise
-   *
-   * @returns Array of Google Conversion Services
-   */
-  async observeGcsViaGtm(
-    gtmUrl: string,
-    args?: string,
-    headless?: string,
-  ): Promise<string[]> {
-    await this.goToPageViaGtm(gtmUrl, args, headless);
-    const responses = await this.crawlPageResponses();
-    return this.puppeteerService.getGcs(responses);
-  }
-
-  /**
-   * @method observeAndKeepGcsAnomaliesViaGtm
-   * Observe the Google Conversion Services of a page via GTM interface and keep track of any anomalies
-   *
-   * @param {string} gtmUrl URL of the Google Tag Manager interface
-   * @param {string} expectValue expected Google Conversion Service
-   * @param {number} loops number of times to observe the Google Conversion Services
-   * @param {string} [args] command line arguments to pass to the browser instance
-   * @param {string} [headless] 'true' to run the browser in headless mode, 'false' otherwise
+   * Observes the Google Consent States (GCS) via GTM and keeps track of any anomalies in the GCS.
+   * @param gtmUrl The URL of the GTM interface.
+   * @param expectValue The value to expect in the GCS.
+   * @param loops The number of loops to perform.
+   * @param chunks The number of chunks to divide the loops into for parallel processing.
+   * @param args Optional command-line arguments to pass to the browser instance.
+   * @param headless Optional boolean flag indicating whether to run the browser in headless mode.
+   * @returns An array of reports for any GCS anomalies detected.
    */
   async observeAndKeepGcsAnomaliesViaGtm(
     gtmUrl: string,
     expectValue: string,
     loops: number,
+    chunks: number,
     args?: string,
     headless?: string,
   ) {
     const report = [];
     let anomalyCount = 0;
-    for (let i = 0; i < loops; i++) {
-      const gcs = await this.observeGcsViaGtm(gtmUrl, args, headless);
-      // console.log(gcs);
-      if (!gcs.includes(expectValue)) {
-        console.log('GCS anomaly detected!');
-        console.log(gcs);
-        anomalyCount++;
-        report.push({
-          anomalyCount: anomalyCount,
-          gcs: gcs,
-          date: new Date(),
-        });
-        // return;
-      } else {
-        console.log('No anomalies detected!');
-        report.push({
-          anomalyCount: anomalyCount,
-          gcs: gcs,
-          date: new Date(),
-        });
-        await this.testingPage.browser().close();
-      }
+    const chunkedLoops = chunk(
+      Array.from({ length: loops }, (_, i) => i),
+      chunks,
+    );
+
+    for (let i = 0; i < chunkedLoops.length; i++) {
+      const chunkReport = await Promise.all(
+        chunkedLoops[i].map(async () => {
+          const { browser, gcs } = await this.observeGcsViaGtm(
+            gtmUrl,
+            args,
+            headless,
+          );
+          if (!gcs.includes(expectValue)) {
+            console.log(
+              'GCS anomaly detected! ' +
+                'Batch: ' +
+                (i + 1) +
+                ' with instances ' +
+                chunkedLoops[i],
+            );
+            console.log(gcs);
+            anomalyCount++;
+            await browser.close();
+            return {
+              anomalyCount: anomalyCount,
+              gcs: gcs,
+              date: new Date(),
+            };
+          } else {
+            console.log(
+              'GCS anomaly not detected! ' +
+                'Batch: ' +
+                (i + 1) +
+                ' with instances ' +
+                chunkedLoops[i],
+            );
+            await browser.close();
+            return {
+              anomalyCount: anomalyCount,
+              gcs: gcs,
+              date: new Date(),
+            };
+          }
+        }),
+      );
+      report.push(...chunkReport);
     }
     return report;
-  }
-
-  async observeAndKeepGcsAnomaliesViaGtmWithReport(
-    gtmUrl: string,
-    expectValue: string,
-    loops: number,
-    args?: string,
-    headless?: string,
-  ) {
-    this.observeAndKeepGcsAnomaliesViaGtm(
-      gtmUrl,
-      expectValue,
-      loops,
-      args,
-      headless,
-    );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(8080);
 }
 bootstrap();

--- a/src/puppeteer/puppeteer.service.spec.ts
+++ b/src/puppeteer/puppeteer.service.spec.ts
@@ -1,21 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PuppeteerService } from './puppeteer.service';
+import { Browser } from 'puppeteer';
 
 export const mockPuppeteerService = {
-  initBrowser: jest
-    .fn()
-    .mockImplementation(() => mockPuppeteerService.setBrowser({})),
-  setBrowser: jest.fn(),
-  getBrowser: jest.fn().mockReturnValue({}),
-  initPage: jest
-    .fn()
-    .mockImplementation(() => mockPuppeteerService.setPage({})),
-  setPage: jest.fn(),
-  getPage: jest.fn().mockReturnValue({}),
-  goToPage: jest.fn().mockImplementation(() => mockPuppeteerService.getPage()),
   getDataLayer: jest.fn().mockReturnValue(['dom.js']),
-  closeBrowser: jest.fn(),
-  closePage: jest.fn(),
   getOperationJson: jest.fn().mockReturnValue({
     name: 'eeListClick',
     steps: [
@@ -30,31 +18,39 @@ export const mockPuppeteerService = {
       },
     ],
   }),
-  performOperation: jest
-    .fn()
-    .mockImplementation(() => mockPuppeteerService.clickElement()),
+  performOperation: jest.fn(),
   clickElement: jest.fn(),
   getInstalledGtms: jest
     .fn()
     .mockImplementation(() => mockPuppeteerService.getAllRequests()),
   getAllRequests: jest.fn().mockReturnValue(['GTM-XXXXXX']),
-  initPuppeteerService: jest.fn().mockImplementation(() => {
-    mockPuppeteerService.initBrowser();
-    mockPuppeteerService.initPage();
-  }),
   initGetDataLayerOperation: jest.fn().mockImplementation((url: string) => {
-    mockPuppeteerService.initPuppeteerService();
-    mockPuppeteerService.goToPage(url);
-    return mockPuppeteerService.getDataLayer();
+    const browser = mockPuppeteerService.initAndReturnBrowser();
+    const page = mockPuppeteerService.gotoAndReturnPage(url, browser);
+    return mockPuppeteerService.getDataLayer(page);
   }),
   getGcs: jest.fn().mockReturnValue(['111']),
-  detectGtm: jest.fn().mockImplementation(async () => {
-    await mockPuppeteerService.initPuppeteerService();
-    const result = await mockPuppeteerService.getInstalledGtms();
-    await mockPuppeteerService.closePage();
+  detectGtm: jest.fn().mockImplementation(async (url: string) => {
+    const browser = mockPuppeteerService.initAndReturnBrowser();
+    const page = mockPuppeteerService.gotoAndReturnPage(url, browser);
+    const result = await mockPuppeteerService.getInstalledGtms(url);
+    browser.close = jest.fn();
+    await browser.close();
     return result;
   }),
   performOperationViaGtm: jest.fn(),
+  initAndReturnBrowser: jest
+    .fn()
+    .mockReturnValue(async (puppeteer, settings: {}) => {
+      return await puppeteer.launch({ ...settings });
+    }),
+  gotoAndReturnPage: jest
+    .fn()
+    .mockReturnValue(async (url: string, browser: Browser) => {
+      const page = browser.newPage();
+      (await page).goto(url);
+      return page;
+    }),
 };
 
 describe('PuppeteerService', () => {
@@ -78,38 +74,32 @@ describe('PuppeteerService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should init the Puppeteer and set the browser for global use', async () => {
+  it('should init the Puppeteer and return the browser for the specific instance', async () => {
     // actual
-    await service.initBrowser();
+    const browser = await service.initAndReturnBrowser();
     // assert
-    expect(service.setBrowser).toHaveBeenCalled();
-    expect(service.setBrowser).toHaveBeenCalledTimes(1);
+    expect(browser).toBeDefined();
   });
 
-  it('should init a new page and set the page for global use', async () => {
-    // actual
-    await service.initPage();
-    // assert
-    expect(service.setPage).toHaveBeenCalled();
-    expect(service.setPage).toHaveBeenCalledTimes(1);
-  });
-
-  it('should go the specific page', async () => {
+  it('should go to the page and return the page instance', async () => {
     // arrange
     const url = 'https://www.google.com';
     // actual
-    await service.goToPage(url);
+    const browser = await service.initAndReturnBrowser();
+    const page = await service.gotoAndReturnPage(url, browser);
     // assert
-    expect(service.getPage).toHaveBeenCalled();
-    expect(service.getPage).toHaveBeenCalledTimes(1);
+    expect(service.initAndReturnBrowser).toHaveBeenCalled();
+    expect(service.gotoAndReturnPage).toHaveBeenCalled();
+    expect(page).toBeDefined();
   });
 
   it('should print out the dataLayer', async () => {
     // arrange
     const url = 'https://www.google.com';
     // actual
-    await service.goToPage(url);
-    const dataLayer = await service.getDataLayer();
+    const browser = await service.initAndReturnBrowser();
+    const page = await service.gotoAndReturnPage(url, browser);
+    const dataLayer = await service.getDataLayer(page);
     // assert
     expect(dataLayer).toBeDefined();
   });
@@ -124,62 +114,65 @@ describe('PuppeteerService', () => {
   it('should perform operation according to the JSON recording', async () => {
     // arrange
     const url = 'https://www.google.com';
+    const browser = await service.initAndReturnBrowser();
+    const page = await service.gotoAndReturnPage(url, browser);
     // actual
-    await service.goToPage(url);
     const operation = service.getOperationJson('eeListClick');
-    await service.performOperation(operation);
+    await service.performOperation(page, operation);
     // assert
     expect(operation).toBeInstanceOf(Object);
-    expect(service.getPage).toHaveBeenCalled();
-    expect(service.goToPage).toHaveBeenCalled();
-    expect(service.clickElement).toHaveBeenCalled();
+    expect(service.gotoAndReturnPage).toHaveBeenCalled();
   });
 
   it('should give the installed GTM according to the URL', async () => {
     // arrange
     const url = 'https://www.google.com';
+    const browser = await service.initAndReturnBrowser();
+    const page = await service.gotoAndReturnPage(url, browser);
     // actual
-    const gtm = await service.getInstalledGtms(url);
+    const gtm = await service.getInstalledGtms(page, url);
     // assert
     expect(service.getAllRequests).toHaveBeenCalled();
     expect(gtm.length).toBeGreaterThan(0);
-  });
-
-  it('should init the PuppeteerService', async () => {
-    // actual
-    await service.initPuppeteerService();
-    // assert
-    expect(service.initBrowser).toHaveBeenCalled();
-    expect(service.initPage).toHaveBeenCalled();
   });
 
   describe('should initGetDataLayerOption', () => {
     // arrange
     const url = 'https://www.google.com';
     // assert
-    it('should initPuppeteerService', async () => {
+    it('should initAndReturnBrowser', async () => {
       // actual
-      await service.initGetDataLayerOperation(url);
+      const browser = await service.initAndReturnBrowser();
+      const page = await service.gotoAndReturnPage(url, browser);
       // assert
-      expect(service.initPuppeteerService).toHaveBeenCalled();
+      expect(service.initAndReturnBrowser).toHaveBeenCalled();
+      expect(browser).toBeDefined();
+      expect(page).toBeDefined();
     });
 
-    it('should goToPage', async () => {
+    it('should gotoAndReturnPage', async () => {
       // actual
-      await service.initGetDataLayerOperation(url);
+      const browser = await service.initAndReturnBrowser();
+      const page = await service.gotoAndReturnPage(url, browser);
       // assert
-      expect(service.goToPage).toHaveBeenCalled();
+      expect(service.gotoAndReturnPage).toHaveBeenCalled();
+      expect(page).toBeDefined();
     });
 
     it('should getDataLayer', async () => {
       // actual
-      await service.initGetDataLayerOperation(url);
+      const browser = await service.initAndReturnBrowser();
+      const page = await service.gotoAndReturnPage(url, browser);
+      const actual = await service.getDataLayer(page);
       // assert
       expect(service.getDataLayer).toHaveBeenCalled();
+      expect(actual).toBeDefined();
     });
 
     it('should return the dataLayer', async () => {
       // actual
+      const browser = await service.initAndReturnBrowser();
+      const page = await service.gotoAndReturnPage(url, browser);
       const dataLayer = await service.initGetDataLayerOperation(url);
       // assert
       expect(dataLayer).toBeDefined();
@@ -190,23 +183,47 @@ describe('PuppeteerService', () => {
     // arrange
     const url = 'https://www.104.com.tw/jobs/main/';
     // assert
-    it('should initPupeeteerService', async () => {
+    it('should initAndReturnBrowser', async () => {
       await service.detectGtm(url);
-      expect(service.initPuppeteerService).toHaveBeenCalled();
-      expect(service.initPuppeteerService).toHaveBeenCalledTimes(1);
+      expect(service.initAndReturnBrowser).toHaveBeenCalled();
+      expect(service.initAndReturnBrowser).toHaveBeenCalledTimes(1);
+    });
+    it('should gotoAndReturnPage', async () => {
+      await service.detectGtm(url);
+      expect(service.gotoAndReturnPage).toHaveBeenCalled();
+      expect(service.gotoAndReturnPage).toHaveBeenCalledTimes(1);
     });
     it('should getInstalledGtms', async () => {
-      await service.detectGtm(url);
+      const actual = await service.detectGtm(url);
       expect(service.getInstalledGtms).toHaveBeenCalled();
       expect(service.getInstalledGtms).toHaveBeenCalledTimes(1);
     });
-    it('should closePage', async () => {
+    it('browser should close', async () => {
+      const browser = await service.initAndReturnBrowser();
+      const page = await service.gotoAndReturnPage(url, browser);
       await service.detectGtm(url);
-      expect(service.closePage).toHaveBeenCalled();
+      expect(browser.close).toHaveBeenCalled();
     });
     it('should return GTM ids', async () => {
       const actual = await service.detectGtm(url);
       expect(actual.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('should init puppeteer and return its instance browser and page', () => {
+    // assert
+    it('should initAndReturnBrowser', async () => {
+      const browser = await service.initAndReturnBrowser();
+      expect(service.initAndReturnBrowser).toBeCalled();
+      expect(browser).toBeDefined();
+    });
+    it('should return page', async () => {
+      const browser = await service.initAndReturnBrowser();
+      const actual = await service.gotoAndReturnPage(
+        'https://www.google.com',
+        browser,
+      );
+      expect(actual).toBeDefined();
     });
   });
 });

--- a/src/puppeteer/puppeteer.service.ts
+++ b/src/puppeteer/puppeteer.service.ts
@@ -4,151 +4,108 @@ import { OPERATIONS, USER_AGENT } from '../configs/puppeteer.config';
 import { ExtractOperation } from '../interfaces/getOperation.interface';
 @Injectable()
 export class PuppeteerService implements ExtractOperation {
-  private browser: Browser;
-  private page: Page;
-
   /**
-   * Initializes a new instance of the browser using Puppeteer.
-   *
-   * @param {Object} [settings={}] - The settings to use for the browser instance.
-   * @return A promise that resolves when the browser has been initialized.
+   * Initializes and returns a browser instance
+   * @param settings Optional browser settings
+   * @returns A Promise resolving to the Browser instance
    */
-  async initBrowser(settings?: any) {
-    this.setBrowser(
-      await puppeteer.launch({
-        ...settings,
-      }),
-    );
-  }
-
-  setBrowser(browser: Browser) {
-    this.browser = browser;
-  }
-
-  getBrowser() {
-    return this.browser;
+  async initAndReturnBrowser(settings?: object) {
+    return await puppeteer.launch({ ...settings });
   }
 
   /**
-   * Initializes a new page instance in the browser.
-   *
-   * @return A promise that resolves when the page has been initialized.
+   * Navigates to a URL and returns the page
+   * @param url The URL to navigate to
+   * @param browser The browser instance to use
+   * @returns A Promise resolving to the Page instance
    */
-  async initPage() {
-    this.setPage(await this.browser.newPage());
-  }
-
-  setPage(page: Page) {
-    this.page = page;
-  }
-
-  getPage() {
-    return this.page;
+  async gotoAndReturnPage(url: string, browser: Browser) {
+    const page = await browser.newPage();
+    await page.goto(url);
+    return page;
   }
 
   /**
-   * Initializes the Puppeteer service by calling the `initBrowser` and `initPage` methods.
-   *
-   * @param settings - The settings to use for the browser instance.
-   * @returns A promise that resolves when the Puppeteer service has been initialized.
-   */
-  async initPuppeteerService(settings?: object) {
-    await this.initBrowser(settings);
-    await this.initPage();
-  }
-
-  /**
-   * Initializes a new data layer operation by calling the `initPuppeteerService`, `goToPage`, and `getDataLayer` methods.
-   * Closes the page after the data layer has been retrieved.
-   *
-   * @param url - The URL to navigate to and retrieve the data layer from.
-   * @returns A promise that resolves with the data layer object.
+   * Initializes Puppeteer, navigates to a URL, retrieves the data layer, and closes the browser
+   * @param url The URL to navigate to
+   * @returns A Promise resolving to an array of data layer objects
    */
   async initGetDataLayerOperation(url: string) {
-    await this.initPuppeteerService();
-    await this.goToPage(url);
-    const result = await this.getDataLayer();
-    await this.closePage();
+    const browser = await this.initAndReturnBrowser();
+    const page = await this.gotoAndReturnPage(url, browser);
+    const result = await this.getDataLayer(page);
+    await browser.close();
     return result;
   }
 
   /**
-   * Navigates the Puppeteer page to the specified URL.
-   * Handles HTTP authentication if necessary.
-   *
-   * @param url - The URL to navigate to.
-   * @returns A promise that resolves when the navigation has completed.
+   * Retrieves the data layer from a page
+   * @param page The page to retrieve the data layer from
+   * @param seconds Optional time in milliseconds to wait before retrieving the data layer
+   * @returns A Promise resolving to an array of data layer objects
    */
-  async goToPage(url: string) {
-    const response = await this.getPage().goto(url, {
-      waitUntil: 'networkidle2',
-    });
-    if (response.status() === 401) {
-      await this.httpAuth(this.getPage(), this.getAuthCredentials());
-      await this.getPage().goto(url);
-    } else {
-      await this.getPage().goto(url);
-    }
-  }
-
-  /**
-   * Retrieves the `dataLayer` from the current Puppeteer page.
-   *
-   * @param seconds - The number of seconds to wait before retrieving the `dataLayer`. Defaults to 1000.
-   * @returns A promise that resolves with the `dataLayer` as an array.
-   */
-  async getDataLayer(seconds: number = 1000): Promise<any[]> {
+  async getDataLayer(page: Page, seconds: number = 1000): Promise<any[]> {
     await new Promise(resolve => setTimeout(resolve, seconds));
-    return await this.getPage().evaluate(() => {
+    return await page.evaluate(() => {
       return window.dataLayer;
     });
   }
 
-  async closeBrowser() {
-    await this.getBrowser().close();
-  }
-
-  async closePage() {
-    await this.getPage().close();
-  }
-
+  /**
+   * Returns the operation JSON object for a given operation name
+   * @param name The name of the operation
+   * @returns The operation JSON object
+   */
   getOperationJson(name: string) {
     return OPERATIONS.find(op => op.name === name).operation;
   }
 
   /**
-   * Performs a series of operations on the page instance.
-   *
-   * @param operation - The operation object containing steps to perform.
-   * @returns A promise that resolves when all steps have been performed.
+   * Performs an operation on a page
+   * @param page The page to perform the operation on
+   * @param operation The operation to perform
+   * @returns A Promise resolving when the operation is complete
    */
-  async performOperation(operation: any) {
+  async performOperation(page: Page, operation: any) {
     // TODO: step.type could be Enum; there are more step.type
     if (!operation) return;
     for (let i = 1; i < operation.steps.length; i++) {
       const step = operation.steps[i];
       if (step.type === 'navigate') {
-        await this.goToPage(step.url);
+        await page.goto(step.url);
       }
       if (step.type === 'click') {
         step.selectors.length == 2
-          ? await this.clickElement(this.getPage(), step.selectors[1][0])
-          : await this.clickElement(this.getPage(), step.selectors[0][0]);
+          ? await this.clickElement(page, step.selectors[1][0])
+          : await this.clickElement(page, step.selectors[0][0]);
       }
     }
   }
 
+  /**
+   * Performs an operation on a page and retrieves the data layer
+   * @param operation The operation to perform
+   * @returns A Promise resolving to an array of data layer objects
+   */
   async performActionAndGetDataLayer(operation: any) {
-    // const operation = this.puppeteerService.getOperationJson(name);
     if (!operation) return;
-    await this.initPuppeteerService(operation.steps[0]);
-    await this.performOperation(operation);
-    const result = await this.getDataLayer();
+
+    const browser = await this.initAndReturnBrowser(operation.step[0]);
+    const page = await this.gotoAndReturnPage(operation.steps[1].url, browser);
+
+    await this.performOperation(page, operation);
+    const result = await this.getDataLayer(page);
     // console.dir('result', result);
-    await this.closePage();
+    await browser.close();
     return result;
   }
 
+  /**
+   * Performs a Google Tag Manager operation on a page
+   * @param page The page to perform the operation on
+   * @param operation The operation to perform
+   * @returns A Promise resolving when the operation is complete
+   */
   async performOperationViaGtm(page: Page, operation: any) {
     if (!operation) return;
     // TODO: step.type could be Enum; there are more step.type
@@ -163,11 +120,10 @@ export class PuppeteerService implements ExtractOperation {
   }
 
   /**
-   * Clicks on the element specified by the selector.
-   *
-   * @param {puppeteer.Page} page - The Puppeteer Page object.
-   * @param {string} selector - The selector for the element to click.
-   * @returns Returns a Promise that resolves once the element has been clicked.
+   * Clicks an element on a page
+   * @param page The page containing the element
+   * @param selector The selector for the element to click
+   * @returns A Promise resolving when the element is clicked
    */
   async clickElement(page: Page, selector: string) {
     console.log('click element');
@@ -176,7 +132,12 @@ export class PuppeteerService implements ExtractOperation {
     });
   }
 
-  // http authentication if encountered
+  /**
+   * Performs HTTP authentication on a page
+   * @param page The page to authenticate
+   * @param credentials The authentication credentials
+   * @returns A Promise resolving when authentication is complete
+   */
   async httpAuth(page: Page, credentials: any) {
     await page.authenticate({
       username: credentials.username,
@@ -184,8 +145,12 @@ export class PuppeteerService implements ExtractOperation {
     });
   }
 
-  // TODO: a way to get the credentials from a file
+  /**
+   * Retrieves the authentication credentials
+   * @returns The authentication credentials object
+   */
   getAuthCredentials(): any {
+    // TODO: get credentials from provider
     return {
       username: 'username',
       password: 'password',
@@ -193,12 +158,13 @@ export class PuppeteerService implements ExtractOperation {
   }
 
   /**
-   * Get all installed Google Tag Manager ids from the given URL
-   * @param {string} url - URL from where to extract the GTM ids
-   * @returns An array of GTM ids
+   * Retrieves the Google Tag Manager IDs installed on a page
+   * @param page The page to retrieve the IDs from
+   * @param url The URL of the page
+   * @returns A Promise resolving to an array of GTM
    */
-  async getInstalledGtms(url: string) {
-    const requests = await this.getAllRequests(url);
+  async getInstalledGtms(page: Page, url: string) {
+    const requests = await this.getAllRequests(page, url);
     const gtmRequests = requests.filter(request =>
       request.includes('collect?v=2'),
     );
@@ -212,17 +178,17 @@ export class PuppeteerService implements ExtractOperation {
   }
 
   /**
-   * Collects all requests made on the page.
-   *
-   * @param url - The URL to the page.
-   * @returns An array of request URLs.
+   * Retrieves all network requests made by a page
+   * @param page The page to retrieve requests from
+   * @param url The URL of the page
+   * @returns A Promise resolving to an array of request URLs
    */
-  async getAllRequests(url: string) {
-    const requests = [];
-    await this.getPage().setRequestInterception(true);
-    await this.getPage().setUserAgent(USER_AGENT);
+  async getAllRequests(page: Page, url: string) {
+    const requests: string[] = [];
+    await page.setRequestInterception(true);
+    await page.setUserAgent(USER_AGENT);
 
-    this.getPage().on('request', async request => {
+    page.on('request', async request => {
       try {
         if (request.isInterceptResolutionHandled()) return;
         requests.push(request.url());
@@ -232,27 +198,32 @@ export class PuppeteerService implements ExtractOperation {
       }
     });
 
-    await this.goToPage(url);
-    await this.getPage().reload({ waitUntil: 'networkidle2' });
+    await page.goto(url);
+    await page.reload({ waitUntil: 'networkidle2' });
     return requests;
   }
 
   /**
-   * Extracts Google Consent Status tracking codes from an array of URL strings
-   * @param {string[]} requests - An array of URL strings
-   * @returns An array of Google Consent Status
+   * Retrieves the Google Click ID (GCLID) values from an array of request URLs
+   * @param requests The array of request URLs to retrieve GCLIDs from
+   * @returns An array of GCLID values
    */
   getGcs(requests: string[]) {
-    // stripe the gcs= from the request
     if (!requests) return [];
     return requests.map(request => request.split('gcs=')[1].split('&')[0]);
   }
 
+  /**
+   * Detects Google Tag Manager installations on a page
+   * @param url The URL of the page to detect installations on
+   * @returns A Promise resolving to an array of GTM IDs
+   */
   async detectGtm(url: string) {
-    await this.initPuppeteerService();
-    const result = await this.getInstalledGtms(url);
+    const browser = await this.initAndReturnBrowser();
+    const page = await this.gotoAndReturnPage(url, browser);
+    const result = await this.getInstalledGtms(page, url);
     // console.dir('result', result);
-    await this.closePage();
+    await browser.close();
     return result;
   }
 }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,0 +1,5 @@
+export function chunk(array: any[], chunkSize: number) {
+  return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, i) =>
+    array.slice(i * chunkSize, i * chunkSize + chunkSize),
+  );
+}


### PR DESCRIPTION
1. refactor the entire Puppeteer codebase to run parallel Puppeteer instances.
2. refactor the test cases to reflect the codebase changes; the gcs checker can run multiple GTM instances parallelly, i.e., faster.