### PR TITLE
Refactor puppeteer service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nestjs/axios": "^1.0.1",
         "@nestjs/common": "^9.0.0",
-        "@nestjs/config": "^2.2.0",
+        "@nestjs/config": "^2.3.4",
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "puppeteer": "^19.5.2",
@@ -1521,27 +1521,19 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.2.0.tgz",
-      "integrity": "sha512-78Eg6oMbCy3D/YvqeiGBTOWei1Jwi3f2pSIZcZ1QxY67kYsJzTRTkwRT8Iv30DbK0sGKc1mcloDLD5UXgZAZtg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.3.4.tgz",
+      "integrity": "sha512-IGdSF+0F9MJO6dCRTEahdxPz4iVijjtolcFBxnY+2QYM3bXYQvAgzskGZi+WkAFJN/VzR3TEp60gN5sI74GxPA==",
       "dependencies": {
-        "dotenv": "16.0.1",
-        "dotenv-expand": "8.0.3",
+        "dotenv": "16.1.4",
+        "dotenv-expand": "10.0.0",
         "lodash": "4.17.21",
-        "uuid": "8.3.2"
+        "uuid": "9.0.0"
       },
       "peerDependencies": {
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^6.0.0 || ^7.2.0"
-      }
-    },
-    "node_modules/@nestjs/config/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nestjs/core": {
@@ -3465,17 +3457,20 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
-      "integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
       "engines": {
         "node": ">=12"
       }
@@ -9731,21 +9726,14 @@
       }
     },
     "@nestjs/config": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.2.0.tgz",
-      "integrity": "sha512-78Eg6oMbCy3D/YvqeiGBTOWei1Jwi3f2pSIZcZ1QxY67kYsJzTRTkwRT8Iv30DbK0sGKc1mcloDLD5UXgZAZtg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.3.4.tgz",
+      "integrity": "sha512-IGdSF+0F9MJO6dCRTEahdxPz4iVijjtolcFBxnY+2QYM3bXYQvAgzskGZi+WkAFJN/VzR3TEp60gN5sI74GxPA==",
       "requires": {
-        "dotenv": "16.0.1",
-        "dotenv-expand": "8.0.3",
+        "dotenv": "16.1.4",
+        "dotenv-expand": "10.0.0",
         "lodash": "4.17.21",
-        "uuid": "8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "uuid": "9.0.0"
       }
     },
     "@nestjs/core": {
@@ -11205,14 +11193,14 @@
       }
     },
     "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw=="
     },
     "dotenv-expand": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-8.0.3.tgz",
-      "integrity": "sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@nestjs/axios": "^1.0.1",
     "@nestjs/common": "^9.0.0",
-    "@nestjs/config": "^2.2.0",
+    "@nestjs/config": "^2.3.4",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "puppeteer": "^19.5.2",

--- a/src/puppeteer/puppeteer.controller.spec.ts
+++ b/src/puppeteer/puppeteer.controller.spec.ts
@@ -27,10 +27,10 @@ describe('PuppeteerController', () => {
     // actual
     const url = 'https://www.104.com.tw/jobs/main/';
     // assert
-    it('should initGetDataLayerOperation', async () => {
+    it('should fetchDataLayer', async () => {
       const actual = await controller.getDataLayer(url);
-      expect(service.initGetDataLayerOperation).toHaveBeenCalled();
-      expect(service.initGetDataLayerOperation).toHaveBeenCalledTimes(1);
+      expect(service.fetchDataLayer).toHaveBeenCalled();
+      expect(service.fetchDataLayer).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/puppeteer/puppeteer.controller.ts
+++ b/src/puppeteer/puppeteer.controller.ts
@@ -7,7 +7,7 @@ export class PuppeteerController {
   @Get('/data-layer')
   async getDataLayer(@Query('url') url: string) {
     console.log('getDataLayer', url);
-    return await this.puppeteerService.initGetDataLayerOperation(url);
+    return await this.puppeteerService.fetchDataLayer(url);
   }
 
   // for demo purposes

--- a/src/puppeteer/puppeteer.service.spec.ts
+++ b/src/puppeteer/puppeteer.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PuppeteerService } from './puppeteer.service';
 import { Browser } from 'puppeteer';
 
+// mock the target service because it depends on puppeteer and browser
 export const mockPuppeteerService = {
   getDataLayer: jest.fn().mockReturnValue(['dom.js']),
   getOperationJson: jest.fn().mockReturnValue({
@@ -24,15 +25,15 @@ export const mockPuppeteerService = {
     .fn()
     .mockImplementation(() => mockPuppeteerService.getAllRequests()),
   getAllRequests: jest.fn().mockReturnValue(['GTM-XXXXXX']),
-  initGetDataLayerOperation: jest.fn().mockImplementation((url: string) => {
+  fetchDataLayer: jest.fn().mockImplementation((url: string) => {
     const browser = mockPuppeteerService.initAndReturnBrowser();
-    const page = mockPuppeteerService.gotoAndReturnPage(url, browser);
+    const page = mockPuppeteerService.nativateTo(url, browser);
     return mockPuppeteerService.getDataLayer(page);
   }),
   getGcs: jest.fn().mockReturnValue(['111']),
   detectGtm: jest.fn().mockImplementation(async (url: string) => {
     const browser = mockPuppeteerService.initAndReturnBrowser();
-    const page = mockPuppeteerService.gotoAndReturnPage(url, browser);
+    const page = mockPuppeteerService.nativateTo(url, browser);
     const result = await mockPuppeteerService.getInstalledGtms(url);
     browser.close = jest.fn();
     await browser.close();
@@ -44,7 +45,7 @@ export const mockPuppeteerService = {
     .mockReturnValue(async (puppeteer, settings: {}) => {
       return await puppeteer.launch({ ...settings });
     }),
-  gotoAndReturnPage: jest
+  nativateTo: jest
     .fn()
     .mockReturnValue(async (url: string, browser: Browser) => {
       const page = browser.newPage();
@@ -74,23 +75,21 @@ describe('PuppeteerService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should init the Puppeteer and return the browser for the specific instance', async () => {
-    // actual
-    const browser = await service.initAndReturnBrowser();
-    // assert
-    expect(browser).toBeDefined();
-  });
-
-  it('should go to the page and return the page instance', async () => {
-    // arrange
+  describe('Initialization and Navigation', () => {
     const url = 'https://www.google.com';
-    // actual
-    const browser = await service.initAndReturnBrowser();
-    const page = await service.gotoAndReturnPage(url, browser);
-    // assert
-    expect(service.initAndReturnBrowser).toHaveBeenCalled();
-    expect(service.gotoAndReturnPage).toHaveBeenCalled();
-    expect(page).toBeDefined();
+
+    it('should init the Puppeteer and return the browser for the specific instance', async () => {
+      const browser = await service.initAndReturnBrowser();
+      expect(browser).toBeDefined();
+    });
+
+    it('should navigate to the page and return the page instance', async () => {
+      const browser = await service.initAndReturnBrowser();
+      const page = await service.nativateTo(url, browser);
+      expect(service.initAndReturnBrowser).toHaveBeenCalled();
+      expect(service.nativateTo).toHaveBeenCalledWith(url, browser);
+      expect(page).toBeDefined();
+    });
   });
 
   it('should print out the dataLayer', async () => {
@@ -98,7 +97,7 @@ describe('PuppeteerService', () => {
     const url = 'https://www.google.com';
     // actual
     const browser = await service.initAndReturnBrowser();
-    const page = await service.gotoAndReturnPage(url, browser);
+    const page = await service.nativateTo(url, browser);
     const dataLayer = await service.getDataLayer(page);
     // assert
     expect(dataLayer).toBeDefined();
@@ -115,20 +114,20 @@ describe('PuppeteerService', () => {
     // arrange
     const url = 'https://www.google.com';
     const browser = await service.initAndReturnBrowser();
-    const page = await service.gotoAndReturnPage(url, browser);
+    const page = await service.nativateTo(url, browser);
     // actual
     const operation = service.getOperationJson('eeListClick');
     await service.performOperation(page, operation);
     // assert
     expect(operation).toBeInstanceOf(Object);
-    expect(service.gotoAndReturnPage).toHaveBeenCalled();
+    expect(service.nativateTo).toHaveBeenCalled();
   });
 
   it('should give the installed GTM according to the URL', async () => {
     // arrange
     const url = 'https://www.google.com';
     const browser = await service.initAndReturnBrowser();
-    const page = await service.gotoAndReturnPage(url, browser);
+    const page = await service.nativateTo(url, browser);
     // actual
     const gtm = await service.getInstalledGtms(page, url);
     // assert
@@ -136,33 +135,33 @@ describe('PuppeteerService', () => {
     expect(gtm.length).toBeGreaterThan(0);
   });
 
-  describe('should initGetDataLayerOption', () => {
+  describe('should fetchDataLayer', () => {
     // arrange
     const url = 'https://www.google.com';
     // assert
     it('should initAndReturnBrowser', async () => {
       // actual
       const browser = await service.initAndReturnBrowser();
-      const page = await service.gotoAndReturnPage(url, browser);
+      const page = await service.nativateTo(url, browser);
       // assert
       expect(service.initAndReturnBrowser).toHaveBeenCalled();
       expect(browser).toBeDefined();
       expect(page).toBeDefined();
     });
 
-    it('should gotoAndReturnPage', async () => {
+    it('should nativateTo', async () => {
       // actual
       const browser = await service.initAndReturnBrowser();
-      const page = await service.gotoAndReturnPage(url, browser);
+      const page = await service.nativateTo(url, browser);
       // assert
-      expect(service.gotoAndReturnPage).toHaveBeenCalled();
+      expect(service.nativateTo).toHaveBeenCalled();
       expect(page).toBeDefined();
     });
 
     it('should getDataLayer', async () => {
       // actual
       const browser = await service.initAndReturnBrowser();
-      const page = await service.gotoAndReturnPage(url, browser);
+      const page = await service.nativateTo(url, browser);
       const actual = await service.getDataLayer(page);
       // assert
       expect(service.getDataLayer).toHaveBeenCalled();
@@ -172,8 +171,8 @@ describe('PuppeteerService', () => {
     it('should return the dataLayer', async () => {
       // actual
       const browser = await service.initAndReturnBrowser();
-      const page = await service.gotoAndReturnPage(url, browser);
-      const dataLayer = await service.initGetDataLayerOperation(url);
+      const page = await service.nativateTo(url, browser);
+      const dataLayer = await service.fetchDataLayer(url);
       // assert
       expect(dataLayer).toBeDefined();
     });
@@ -188,10 +187,10 @@ describe('PuppeteerService', () => {
       expect(service.initAndReturnBrowser).toHaveBeenCalled();
       expect(service.initAndReturnBrowser).toHaveBeenCalledTimes(1);
     });
-    it('should gotoAndReturnPage', async () => {
+    it('should nativateTo', async () => {
       await service.detectGtm(url);
-      expect(service.gotoAndReturnPage).toHaveBeenCalled();
-      expect(service.gotoAndReturnPage).toHaveBeenCalledTimes(1);
+      expect(service.nativateTo).toHaveBeenCalled();
+      expect(service.nativateTo).toHaveBeenCalledTimes(1);
     });
     it('should getInstalledGtms', async () => {
       const actual = await service.detectGtm(url);
@@ -200,7 +199,7 @@ describe('PuppeteerService', () => {
     });
     it('browser should close', async () => {
       const browser = await service.initAndReturnBrowser();
-      const page = await service.gotoAndReturnPage(url, browser);
+      const page = await service.nativateTo(url, browser);
       await service.detectGtm(url);
       expect(browser.close).toHaveBeenCalled();
     });
@@ -217,9 +216,10 @@ describe('PuppeteerService', () => {
       expect(service.initAndReturnBrowser).toBeCalled();
       expect(browser).toBeDefined();
     });
+
     it('should return page', async () => {
       const browser = await service.initAndReturnBrowser();
-      const actual = await service.gotoAndReturnPage(
+      const actual = await service.nativateTo(
         'https://www.google.com',
         browser,
       );


### PR DESCRIPTION
1. Use Enum for browser actions.
2. Remove redundant methods.
3. Refactor methods to prevent memory leaks; change naming for better understanding.